### PR TITLE
[DRUP-784] Fix edge configuration for non-interactive site install

### DIFF
--- a/apigee_devportal_kickstart.install
+++ b/apigee_devportal_kickstart.install
@@ -83,6 +83,14 @@ function apigee_devportal_kickstart_install() {
  * Implements hook_install_tasks_alter().
  */
 function apigee_devportal_kickstart_install_tasks_alter(&$tasks, $install_state) {
+  // Do not add the apigee_edge_configure_form tasks if non-interactive install
+  // since drush si cannot set default values for the form.
+  // Use `drush key-save apigee_edge_connection_default '{\"auth_type\":\"basic\",\"organization\":\"ORGANIZATION\",\"username\":\"USERNAME\",\"password\":\"PASSWORD"}' --key-type=apigee_auth -y`
+  // to create a key after drush si.
+  if (!$install_state['interactive']) {
+    return;
+  }
+
   // Add a task for configuring Apigee Edge Authentication.
   $tasks_copy = $tasks;
   $apigee_edge_configure_form = [


### PR DESCRIPTION
This PR fixes site install via `drush si`. It hides the Edge configuration install task if site is installed non-interactively.

Use the following command to install the site and create an edge connection key:

`drush si apigee_devportal_kickstart --account-name=admin --account-pass=admin --account-mail='admin@example.com' --site-name='Apigee' --site-mail='admin@example.com' --db-url=mysql://root:root@localhost/database --uri=http://kickstart.test -y; drush key-save apigee_edge_connection_default '{\"auth_type\":\"basic\",\"organization\":\"ORGANIZATION\",\"username\":\"USERNAME\",\"password\":\"PASSWORD\"}' --key-type=apigee_auth -y`